### PR TITLE
feat: condense declaration groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ A configurable Go code formatter that condenses multi-line constructs into singl
 - **Flexible Limits**: Set maximum line length and item count globally or per-feature
 - **Preserves Comments**: All comments are preserved in their original positions
 - **Semantic Safety**: No changes to code semantics or behavior
-- **Multiple Constructs**: Supports imports, functions, literals, structs, slices, maps, and calls
 - **CLI and Library**: Available as both a command-line tool and Go library
 
 ## Installation
@@ -33,9 +32,9 @@ go get github.com/abemedia/gocondense
 
 ## Supported Constructs
 
-### Import Declarations
+### Declaration Groups
 
-Condenses single import declarations from multi-line to single-line format.
+Condenses single-item declaration groups (import, var, const, type) from multi-line to single-line format.
 
 **Before:**
 
@@ -43,15 +42,31 @@ Condenses single import declarations from multi-line to single-line format.
 import (
     "fmt"
 )
+
+var (
+    x = 1
+)
+
+const (
+    Name = "value"
+)
+
+type (
+    ID int
+)
 ```
 
 **After:**
 
 ```go
 import "fmt"
-```
 
-**Note:** Only single imports are condensed. Multi-import blocks are left unchanged to maintain readability.
+var x = 1
+
+const Name = "value"
+
+type ID int
+```
 
 ---
 
@@ -311,24 +326,24 @@ cat myfile.go | gocondense
 
 You can override global settings for specific features:
 
-| Flag                   | Description                                  |
-| ---------------------- | -------------------------------------------- |
-| `--imports.max-len`    | Override max-len for imports                 |
-| `--imports.max-items`  | Override max-items for imports               |
-| `--types.max-len`      | Override max-len for type parameters         |
-| `--types.max-items`    | Override max-items for type parameters       |
-| `--funcs.max-len`      | Override max-len for function declarations   |
-| `--funcs.max-items`    | Override max-items for function declarations |
-| `--literals.max-len`   | Override max-len for function literals       |
-| `--literals.max-items` | Override max-items for function literals     |
-| `--calls.max-len`      | Override max-len for function calls          |
-| `--calls.max-items`    | Override max-items for function calls        |
-| `--structs.max-len`    | Override max-len for struct literals         |
-| `--structs.max-items`  | Override max-items for struct literals       |
-| `--slices.max-len`     | Override max-len for slice literals          |
-| `--slices.max-items`   | Override max-items for slice literals        |
-| `--maps.max-len`       | Override max-len for map literals            |
-| `--maps.max-items`     | Override max-items for map literals          |
+| Flag                       | Description                                  |
+| -------------------------- | -------------------------------------------- |
+| `--declarations.max-len`   | Override max-len for declarations            |
+| `--declarations.max-items` | Override max-items for declarations          |
+| `--types.max-len`          | Override max-len for type parameters         |
+| `--types.max-items`        | Override max-items for type parameters       |
+| `--funcs.max-len`          | Override max-len for function declarations   |
+| `--funcs.max-items`        | Override max-items for function declarations |
+| `--literals.max-len`       | Override max-len for function literals       |
+| `--literals.max-items`     | Override max-items for function literals     |
+| `--calls.max-len`          | Override max-len for function calls          |
+| `--calls.max-items`        | Override max-items for function calls        |
+| `--structs.max-len`        | Override max-len for struct literals         |
+| `--structs.max-items`      | Override max-items for struct literals       |
+| `--slices.max-len`         | Override max-len for slice literals          |
+| `--slices.max-items`       | Override max-items for slice literals        |
+| `--maps.max-len`           | Override max-len for map literals            |
+| `--maps.max-items`         | Override max-items for map literals          |
 
 ### Examples
 
@@ -350,10 +365,10 @@ gocondense --max-items 3 myfile.go
 gocondense --enable calls,structs myfile.go
 ```
 
-**Condense everything except imports:**
+**Condense everything except declarations:**
 
 ```bash
-gocondense --disable imports myfile.go
+gocondense --disable declarations myfile.go
 ```
 
 **Allow more items for function calls than other constructs:**
@@ -370,7 +385,7 @@ gocondense --max-len 80 --structs.max-len 120 myfile.go
 
 ### Available Features
 
-- `imports` - Import declarations
+- `declarations` - Declaration groups (import, var, const, type)
 - `types` - Type parameters and instantiations
 - `funcs` - Function declarations
 - `literals` - Function literals
@@ -453,10 +468,10 @@ config := &gocondense.Config{
     Enable: gocondense.Funcs | gocondense.Calls, // Only functions and calls
 }
 
-// Enable all except imports
+// Enable all except declarations
 config := &gocondense.Config{
     MaxLen: 80,
-    Enable: gocondense.All &^ gocondense.Imports, // All except imports
+    Enable: gocondense.All &^ gocondense.Declarations, // All except declarations
 }
 ```
 

--- a/cmd/gocondense/main.go
+++ b/cmd/gocondense/main.go
@@ -21,15 +21,15 @@ import (
 )
 
 var features = map[string]gocondense.Feature{
-	"imports":  gocondense.Imports,
-	"types":    gocondense.Types,
-	"funcs":    gocondense.Funcs,
-	"literals": gocondense.Literals,
-	"calls":    gocondense.Calls,
-	"structs":  gocondense.Structs,
-	"slices":   gocondense.Slices,
-	"maps":     gocondense.Maps,
-	"all":      gocondense.All,
+	"declarations": gocondense.Declarations,
+	"types":        gocondense.Types,
+	"funcs":        gocondense.Funcs,
+	"literals":     gocondense.Literals,
+	"calls":        gocondense.Calls,
+	"structs":      gocondense.Structs,
+	"slices":       gocondense.Slices,
+	"maps":         gocondense.Maps,
+	"all":          gocondense.All,
 }
 
 //nolint:cyclop,funlen,gocognit

--- a/doc.go
+++ b/doc.go
@@ -3,7 +3,7 @@
 // readability and respecting specified formatting constraints.
 //
 // The formatter can process various Go constructs including:
-//   - Import declarations: Convert multi-line imports to single-line
+//   - Declaration groups: Convert multi-line single-item declarations to single-line
 //   - Function signatures: Condense parameter lists and return values
 //   - Function literals: Compact anonymous function definitions
 //   - Struct literals: Convert multi-line struct initialization to single-line

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -63,11 +63,11 @@ func TestFormatWithConfig(t *testing.T) {
 		want   string
 	}{
 		{
-			name: "disabled_imports",
+			name: "disabled_declarations",
 			config: &gocondense.Config{
 				MaxLen:   120,
 				TabWidth: 4,
-				Enable:   gocondense.All &^ gocondense.Imports,
+				Enable:   gocondense.All &^ gocondense.Declarations,
 			},
 			input: `package main
 

--- a/testdata/comments_preserve.golden
+++ b/testdata/comments_preserve.golden
@@ -1,9 +1,0 @@
-package main
-
-import (
-	"fmt" // comment prevents condensing
-)
-
-func main() {
-	fmt.Println("hello")
-}

--- a/testdata/comments_preserve.input
+++ b/testdata/comments_preserve.input
@@ -1,9 +1,0 @@
-package main
-
-import (
-	"fmt" // comment prevents condensing
-)
-
-func main() {
-	fmt.Println("hello")
-}

--- a/testdata/declarations_alias.golden
+++ b/testdata/declarations_alias.golden
@@ -1,0 +1,11 @@
+package main
+
+import f "fmt"
+
+var msg string = "hello"
+
+const PI float64 = 3.14159
+
+type StringAlias = string
+
+func main() {}

--- a/testdata/declarations_alias.input
+++ b/testdata/declarations_alias.input
@@ -1,0 +1,19 @@
+package main
+
+import (
+	f "fmt"
+)
+
+var (
+	msg string = "hello"
+)
+
+const (
+	PI float64 = 3.14159
+)
+
+type (
+	StringAlias = string
+)
+
+func main() {}

--- a/testdata/declarations_body.golden
+++ b/testdata/declarations_body.golden
@@ -1,0 +1,9 @@
+package main
+
+func main() {
+	var message = "hello"
+
+	const pi = 3.14
+
+	type UserID int
+}

--- a/testdata/declarations_body.input
+++ b/testdata/declarations_body.input
@@ -1,0 +1,15 @@
+package main
+
+func main() {
+	var (
+		message = "hello"
+	)
+
+	const (
+		pi = 3.14
+	)
+
+	type (
+		UserID int
+	)
+}

--- a/testdata/declarations_comment.golden
+++ b/testdata/declarations_comment.golden
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt" // formatting library
+)
+
+var (
+	greeting = "hello" // welcome message
+)
+
+const (
+	version = "1.0" // app version
+)
+
+type (
+	ID int // user identifier
+)
+
+func main() {}

--- a/testdata/declarations_comment.input
+++ b/testdata/declarations_comment.input
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt" // formatting library
+)
+
+var (
+	greeting = "hello" // welcome message
+)
+
+const (
+	version = "1.0" // app version
+)
+
+type (
+	ID int // user identifier
+)
+
+func main() {}

--- a/testdata/declarations_mixed.golden
+++ b/testdata/declarations_mixed.golden
@@ -1,0 +1,11 @@
+package main
+
+var x, y = 1, 2
+
+const A, B string = "a", "b"
+
+var name string = "test"
+
+const count int = 42
+
+func main() {}

--- a/testdata/declarations_mixed.input
+++ b/testdata/declarations_mixed.input
@@ -1,0 +1,19 @@
+package main
+
+var (
+	x, y = 1, 2
+)
+
+const (
+	A, B string = "a", "b"
+)
+
+var (
+	name string = "test"
+)
+
+const (
+	count int = 42
+)
+
+func main() {}

--- a/testdata/declarations_multiple.golden
+++ b/testdata/declarations_multiple.golden
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+var (
+	a = 1
+	b = 2
+)
+
+const (
+	X = "x"
+	Y = "y"
+)
+
+type (
+	Int    int
+	String string
+)
+
+func main() {}

--- a/testdata/declarations_multiple.input
+++ b/testdata/declarations_multiple.input
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+var (
+	a = 1
+	b = 2
+)
+
+const (
+	X = "x"
+	Y = "y"
+)
+
+type (
+	Int int
+	String string
+)
+
+func main() {}

--- a/testdata/declarations_single.golden
+++ b/testdata/declarations_single.golden
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+var message = "hello"
+
+const pi = 3.14
+
+type UserID int
+
+func main() {}

--- a/testdata/declarations_single.input
+++ b/testdata/declarations_single.input
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+)
+
+var (
+	message = "hello"
+)
+
+const (
+	pi = 3.14
+)
+
+type (
+	UserID int
+)
+
+func main() {}

--- a/testdata/imports_alias.golden
+++ b/testdata/imports_alias.golden
@@ -1,5 +1,0 @@
-package main
-
-import f "fmt"
-
-func main() {}

--- a/testdata/imports_alias.input
+++ b/testdata/imports_alias.input
@@ -1,7 +1,0 @@
-package main
-
-import (
-	f "fmt"
-)
-
-func main() {}

--- a/testdata/imports_comment.golden
+++ b/testdata/imports_comment.golden
@@ -1,7 +1,0 @@
-package main
-
-import (
-	"fmt" // formatting library
-)
-
-func main() {}

--- a/testdata/imports_comment.input
+++ b/testdata/imports_comment.input
@@ -1,7 +1,0 @@
-package main
-
-import (
-	"fmt" // formatting library
-)
-
-func main() {}

--- a/testdata/imports_multiple.golden
+++ b/testdata/imports_multiple.golden
@@ -1,8 +1,0 @@
-package main
-
-import (
-	"fmt"
-	"os"
-)
-
-func main() {}

--- a/testdata/imports_multiple.input
+++ b/testdata/imports_multiple.input
@@ -1,8 +1,0 @@
-package main
-
-import (
-	"fmt"
-	"os"
-)
-
-func main() {}

--- a/testdata/imports_single.golden
+++ b/testdata/imports_single.golden
@@ -1,5 +1,0 @@
-package main
-
-import "fmt"
-
-func main() {}

--- a/testdata/imports_single.input
+++ b/testdata/imports_single.input
@@ -1,7 +1,0 @@
-package main
-
-import (
-	"fmt"
-)
-
-func main() {}


### PR DESCRIPTION
Replace `imports` with `declarations` to also condense single-item groups of `type`, `const` and `var`.