### PR TITLE
fix: corrupts files, strips generic types from declaration

### DIFF
--- a/testdata/declaration_generic.golden
+++ b/testdata/declaration_generic.golden
@@ -1,0 +1,13 @@
+package main
+
+type GenericStruct[T any, U comparable] struct {
+	Field T
+}
+
+type GenericFunc[T any, U comparable] func(T, U) bool
+
+type GenericInterface[T any, U comparable] interface {
+	Method(T) U
+}
+
+func main() {}

--- a/testdata/declaration_generic.input
+++ b/testdata/declaration_generic.input
@@ -1,0 +1,22 @@
+package main
+
+type GenericStruct[
+	T any,
+	U comparable,
+] struct {
+	Field T
+}
+
+type GenericFunc[
+	T any,
+	U comparable,
+] func(T, U) bool
+
+type GenericInterface[
+	T any,
+	U comparable,
+] interface {
+	Method(T) U
+}
+
+func main() {}


### PR DESCRIPTION
- Fix corrupting files when running concurrently by removing fset and comments from formatter struct and passing to functions.
- Fix generic types getting stripped from type declarations.