### PR TITLE
feat: condense child expressions independently of their parent

### DIFF
--- a/condenser.go
+++ b/condenser.go
@@ -2,12 +2,10 @@ package gocondense
 
 import (
 	"bytes"
-	"fmt"
 	"go/ast"
 	"go/format"
 	"go/token"
 	"slices"
-	"strings"
 
 	"golang.org/x/tools/go/ast/astutil"
 )
@@ -18,7 +16,6 @@ type condenser struct {
 	fset      *token.FileSet
 	file      *ast.File
 	tokenFile *token.File
-	addLines  map[ast.Node][2]int
 }
 
 // applyPre is called before visiting children nodes.
@@ -51,28 +48,6 @@ func (e *condenser) applyPre(c *astutil.Cursor) bool {
 		e.condenseBlockStmt(n)
 	case ast.Expr:
 		e.condenseExpr(n)
-	}
-
-	return true
-}
-
-// applyPost is called after visiting children nodes.
-func (e *condenser) applyPost(c *astutil.Cursor) bool {
-	node := c.Node()
-	if node == nil {
-		return true
-	}
-
-	lines, ok := e.addLines[node]
-	if !ok {
-		return true
-	}
-	delete(e.addLines, node)
-
-	// If condensing the signature collapsed the body's apparent span to zero,
-	// restore it so an enclosing call does not fold the body onto a single line.
-	if e.line(node.End())-e.line(node.Pos()) < lines[1]-lines[0] {
-		e.addNewline(node.Pos() + 1)
 	}
 
 	return true
@@ -209,15 +184,15 @@ func (e *condenser) condenseCompositeLit(lit *ast.CompositeLit) bool {
 }
 
 // condenseExpr recursively condenses expressions.
-func (e *condenser) condenseExpr(expr ast.Expr) bool {
+func (e *condenser) condenseExpr(expr ast.Expr) bool { //nolint:cyclop,funlen
 	if e.isSingleLine(expr) {
 		return true
 	}
 	switch n := expr.(type) {
 	case *ast.BasicLit:
-		return e.condenseBasicLit(n)
+		return false // Only multi-line raw strings reach here; can't condense without changing the value.
 	case *ast.BinaryExpr:
-		return !e.hasComments(n) && allOK(e.condenseExpr(n.X), e.condenseExpr(n.Y))
+		return e.condenseWithChildren(n, n.X, n.Y)
 	case *ast.CallExpr:
 		return e.condenseCallExpr(n)
 	case *ast.CompositeLit:
@@ -227,83 +202,59 @@ func (e *condenser) condenseExpr(expr ast.Expr) bool {
 	case *ast.FuncType, *ast.InterfaceType:
 		return false
 	case *ast.KeyValueExpr:
-		return !e.hasComments(n) && allOK(e.condenseExpr(n.Key), e.condenseExpr(n.Value))
+		return e.condenseWithChildren(n, n.Key, n.Value)
 	case *ast.MapType:
-		return !e.hasComments(n) && allOK(e.condenseExpr(n.Key), e.condenseExpr(n.Value))
+		return e.condenseWithChildren(n, n.Key, n.Value)
 	case *ast.StructType:
 		if !e.config.Enable.has(Structs) || len(n.Fields.List) > 0 {
+			for _, field := range n.Fields.List {
+				e.condenseExpr(field.Type)
+			}
 			return false
 		}
 		return e.condenseNode(n)
+	case *ast.SelectorExpr:
+		return e.condenseWithChildren(n, n.X)
+	case *ast.UnaryExpr:
+		return e.condenseWithChildren(n, n.X)
+	case *ast.StarExpr:
+		return e.condenseWithChildren(n, n.X)
+	case *ast.IndexExpr:
+		return e.condenseWithChildren(n, n.X, n.Index)
+	case *ast.IndexListExpr:
+		return e.condenseWithChildren(n, append([]ast.Expr{n.X}, n.Indices...)...)
+	case *ast.SliceExpr:
+		return e.condenseWithChildren(n, n.X, n.Low, n.High, n.Max)
+	case *ast.TypeAssertExpr:
+		return e.condenseWithChildren(n, n.X, n.Type)
+	case *ast.ParenExpr:
+		return e.condenseWithChildren(n, n.X)
 	// case *ast.ArrayType:
 	// case *ast.ChanType:
 	// case *ast.Ellipsis:
 	// case *ast.Ident:
-	// case *ast.IndexExpr:
-	// case *ast.IndexListExpr:
-	// case *ast.ParenExpr:
-	// case *ast.UnaryExpr:
-	// case *ast.SelectorExpr:
-	// case *ast.SliceExpr:
-	// case *ast.StarExpr:
-	// case *ast.TypeAssertExpr:
 	default:
 		return !e.hasComments(n) && e.condenseNode(n)
 	}
 }
 
-// condenseBasicLit attempts to condense a basic literal.
-func (e *condenser) condenseBasicLit(lit *ast.BasicLit) bool {
-	if lit.Kind != token.STRING || len(lit.Value) < 2 || lit.Value[0] != '`' {
-		return e.condenseNode(lit) // If it's not a raw string literal, we can condense it.
-	}
-
-	if strings.Contains(lit.Value, "\n") {
-		return false // If it contains newlines, we cannot condense it.
-	}
-
-	return e.condenseNode(lit)
-}
 
 // condenseCallExpr attempts to condense a function call.
 func (e *condenser) condenseCallExpr(call *ast.CallExpr) bool {
-	if !e.config.Enable.has(Calls) || e.hasComments(call) {
+	if !e.config.Enable.has(Calls) {
 		return false
 	}
-	if e.isSingleLine(call) {
-		return true
-	}
-
-	e.condenseExpr(call.Fun)
-
-	canCondense := true
-
-	for _, arg := range call.Args {
-		if ok := e.condenseExpr(arg); !ok {
-			canCondense = false
-		}
-	}
-
-	if !canCondense {
-		return false
-	}
-
-	return e.condenseNode(call)
+	children := append([]ast.Expr{call.Fun}, call.Args...)
+	return e.condenseWithChildren(call, children...)
 }
 
 // condenseFuncDecl attempts to condense a function declaration.
-func (e *condenser) condenseFuncDecl(decl *ast.FuncDecl) bool {
-	if !e.config.Enable.has(Funcs) {
-		return false
+func (e *condenser) condenseFuncDecl(decl *ast.FuncDecl) {
+	if !e.config.Enable.has(Funcs) || e.isSingleLine(decl) {
+		return
 	}
-	if e.isSingleLine(decl) {
-		return true
-	}
-
-	return allOK(
-		e.condenseFieldList(decl.Recv, Funcs),
-		e.condenseFuncType(decl.Type, Funcs),
-	)
+	e.condenseFieldList(decl.Recv, Funcs)
+	e.condenseFuncType(decl.Type, Funcs)
 }
 
 // condenseFuncLit attempts to condense a function literal.
@@ -314,9 +265,6 @@ func (e *condenser) condenseFuncLit(lit *ast.FuncLit) bool {
 	if e.isSingleLine(lit) {
 		return true
 	}
-
-	// Protect the function body from being condensed by parent expressions.
-	e.addLines[lit.Body] = [2]int{e.line(lit.Body.Pos()), e.line(lit.Body.End())}
 
 	return e.condenseFuncType(lit.Type, Literals) && len(lit.Body.List) <= 1
 }
@@ -356,17 +304,6 @@ func (e *condenser) condenseBlockStmt(block *ast.BlockStmt) {
 		trailing++
 	}
 	e.removeLines(rbraceLine-trailing-1, rbraceLine-1)
-
-	// If this block is a function literal body protected by addLines, update the
-	// stored span to reflect blank-line removal so applyPost's guard only fires
-	// if the body is collapsed further by an enclosing expression.
-	// Do not update if the body has already been collapsed (span == 0): in that
-	// case the original span must be preserved so applyPost can still fire.
-	if _, ok := e.addLines[block]; ok {
-		if span := e.line(block.End()) - e.line(block.Pos()); span > 0 {
-			e.addLines[block] = [2]int{e.line(block.Pos()), e.line(block.End())}
-		}
-	}
 }
 
 // condenseFuncType attempts to condense a function type.
@@ -450,22 +387,6 @@ func (e *condenser) removeLines(fromLine, toLine int) {
 	}
 }
 
-// addNewline inserts a new line break at the given position in the token file.
-// It is a no-op if a line already starts at that position.
-func (e *condenser) addNewline(pos token.Pos) {
-	offset := e.fset.Position(pos).Offset
-
-	lines := e.tokenFile.Lines()
-	i, exists := slices.BinarySearch(lines, offset)
-	if exists {
-		return
-	}
-	lines = slices.Insert(lines, i, offset)
-	if !e.tokenFile.SetLines(lines) {
-		panic(fmt.Sprintf("could not set lines to %v", lines))
-	}
-}
-
 // canCondense checks if a node can be condensed without exceeding MaxLen.
 func (e *condenser) canCondense(node ast.Node) bool {
 	maxLen := e.config.MaxLen
@@ -513,6 +434,24 @@ func (e *condenser) condenseNode(node ast.Node) bool {
 	return e.isSingleLine(node)
 }
 
+// condenseWithChildren condenses each child expression, then attempts to
+// condense the parent node if all children are single-line and comment-free.
+func (e *condenser) condenseWithChildren(node ast.Node, children ...ast.Expr) bool {
+	allSingleLine := true
+	for _, child := range children {
+		if child == nil {
+			continue
+		}
+		if !e.condenseExpr(child) || !e.isSingleLine(child) {
+			allSingleLine = false
+		}
+	}
+	if !allSingleLine || e.hasComments(node) {
+		return false
+	}
+	return e.condenseNode(node)
+}
+
 // isComplexExpr reports whether an expression is too complex to condense onto
 // a single line alongside other elements. Composite/func literals and calls
 // are always complex; interfaces are complex when they have more than one method.
@@ -520,6 +459,8 @@ func isComplexExpr(expr ast.Expr) bool {
 	switch n := expr.(type) {
 	case *ast.CompositeLit, *ast.FuncLit, *ast.CallExpr:
 		return true
+	case *ast.KeyValueExpr:
+		return isComplexExpr(n.Value)
 	case *ast.InterfaceType:
 		return len(n.Methods.List) > 1
 	default:
@@ -591,7 +532,3 @@ func equalFieldList(a, b *ast.FieldList) bool {
 	})
 }
 
-// allOK reports whether all of the given condense results were successful.
-func allOK(condensers ...bool) bool {
-	return !slices.Contains(condensers, false)
-}

--- a/formatter.go
+++ b/formatter.go
@@ -216,10 +216,9 @@ func (f *Formatter) Format(src []byte) ([]byte, error) {
 		fset:      fset,
 		file:      file,
 		tokenFile: fset.File(file.Pos()),
-		addLines:  map[ast.Node][2]int{},
 	}
 
-	astutil.Apply(file, editor.applyPre, editor.applyPost)
+	astutil.Apply(file, editor.applyPre, nil)
 
 	var buf bytes.Buffer
 	if err := format.Node(&buf, fset, file); err != nil {

--- a/testdata/comments_children.golden
+++ b/testdata/comments_children.golden
@@ -1,0 +1,21 @@
+package main
+
+func main() {
+	// BinaryExpr: comment in gap, both operands condensable
+	_ = foo(1, 2) + // comment
+		bar(3, 4)
+
+	// CallExpr: comment after arg, children condensable
+	foo(
+		bar(1, 2), // comment
+		baz(3, 4),
+	)
+
+	// CallExpr: comment after arg, one child is FuncLit
+	foo(
+		func() {
+			doSomething()
+		}, // comment
+		bar(1, 2),
+	)
+}

--- a/testdata/comments_children.input
+++ b/testdata/comments_children.input
@@ -1,0 +1,38 @@
+package main
+
+func main() {
+	// BinaryExpr: comment in gap, both operands condensable
+	_ = foo(
+		1,
+		2,
+	) + // comment
+		bar(
+			3,
+			4,
+		)
+
+	// CallExpr: comment after arg, children condensable
+	foo(
+		bar(
+			1,
+			2,
+		), // comment
+		baz(
+			3,
+			4,
+		),
+	)
+
+	// CallExpr: comment after arg, one child is FuncLit
+	foo(
+		func() {
+
+			doSomething()
+			
+		}, // comment
+		bar(
+			1,
+			2,
+		),
+	)
+}

--- a/testdata/complex_nested.golden
+++ b/testdata/complex_nested.golden
@@ -23,9 +23,12 @@ func main() {
 		{Name: "Bob", Age: 25},
 	}
 
-	adults := processData(people, func(p Person) bool {
-		return p.Age >= 18
-	})
+	adults := processData(
+		people,
+		func(p Person) bool {
+			return p.Age >= 18
+		},
+	)
 
 	fmt.Println(adults)
 }

--- a/testdata/deep_nested.golden
+++ b/testdata/deep_nested.golden
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type Item struct {
+	Name  string
+	Value int
+}
+
+type Config struct {
+	Filter    func(Item) bool
+	Transform func(Item) Item
+}
+
+type Pipeline struct {
+	items []Item
+}
+
+func NewPipeline(items []Item, cfg Config) *Pipeline {
+	var result []Item
+	for _, item := range items {
+		if cfg.Filter(item) {
+			result = append(result, cfg.Transform(item))
+		}
+	}
+	return &Pipeline{items: result}
+}
+
+func (p *Pipeline) Items() []Item { return p.items }
+
+func main() {
+	thresholds := []int{3, 7, 15}
+
+	items := []Item{
+		{Name: "alpha", Value: 10},
+		{Name: "beta", Value: 5},
+		{Name: "gamma", Value: 20},
+	}
+
+	// Single deeply nested expression combining:
+	//   - call with struct literal arg (Config) whose KeyValueExprs have FuncLit values
+	//   - FuncLit bodies that contain nested calls with their own FuncLit args
+	//   - BinaryExpr, IndexExpr, SelectorExpr inside those bodies
+	//   - multi-statement FuncLit body (strings.Map callback)
+	//   - chained method call (.Items()) on the result
+	result := NewPipeline(
+		items,
+		Config{
+			Filter: func(item Item) bool {
+				return item.Value > sort.Search(
+					len(thresholds),
+					func(i int) bool {
+						return thresholds[i] >= 7
+					},
+				)
+			},
+			Transform: func(item Item) Item {
+				item.Name = strings.Map(
+					func(r rune) rune {
+						if r >= 'a' && r <= 'z' {
+							return r - 32
+						}
+						return r
+					},
+					item.Name,
+				)
+				return item
+			},
+		},
+	).
+		Items()
+
+	fmt.Println(result)
+}

--- a/testdata/deep_nested.input
+++ b/testdata/deep_nested.input
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type Item struct {
+	Name  string
+	Value int
+}
+
+type Config struct {
+	Filter    func(Item) bool
+	Transform func(Item) Item
+}
+
+type Pipeline struct {
+	items []Item
+}
+
+func NewPipeline(
+	items []Item,
+	cfg Config,
+) *Pipeline {
+	var result []Item
+	for _, item := range items {
+		if cfg.Filter(item) {
+			result = append(result, cfg.Transform(item))
+		}
+	}
+	return &Pipeline{items: result}
+}
+
+func (p *Pipeline) Items() []Item { return p.items }
+
+func main() {
+	thresholds := []int{3, 7, 15}
+
+	items := []Item{
+		{Name: "alpha", Value: 10},
+		{Name: "beta", Value: 5},
+		{Name: "gamma", Value: 20},
+	}
+
+	// Single deeply nested expression combining:
+	//   - call with struct literal arg (Config) whose KeyValueExprs have FuncLit values
+	//   - FuncLit bodies that contain nested calls with their own FuncLit args
+	//   - BinaryExpr, IndexExpr, SelectorExpr inside those bodies
+	//   - multi-statement FuncLit body (strings.Map callback)
+	//   - chained method call (.Items()) on the result
+	result := NewPipeline(
+		items,
+		Config{
+			Filter: func(
+				item Item,
+			) bool {
+				return item.Value > sort.Search(
+					len(thresholds),
+					func(
+						i int,
+					) bool {
+						return thresholds[i] >= 7
+					},
+				)
+			},
+			Transform: func(
+				item Item,
+			) Item {
+				item.Name = strings.Map(
+					func(
+						r rune,
+					) rune {
+						if r >= 'a' && r <= 'z' {
+							return r - 32
+						}
+						return r
+					},
+					item.Name,
+				)
+				return item
+			},
+		},
+	).
+		Items()
+
+	fmt.Println(result)
+}

--- a/testdata/expr_comments.golden
+++ b/testdata/expr_comments.golden
@@ -1,0 +1,44 @@
+package main
+
+func main() {
+	// UnaryExpr with comment
+	_ = !isValid(
+		1, // x
+		2,
+	)
+
+	// IndexExpr with comment
+	_ = getSlice(
+		1, // x
+		2,
+	)[0]
+
+	// SliceExpr with comment
+	_ = getSlice(
+		1, // x
+		2,
+	)[foo(
+		3, // x
+		4,
+	):bar(
+		5, // x
+		6,
+	)]
+
+	// TypeAssertExpr with comment
+	_ = getValue(
+		1, // x
+		2,
+	).(map[ // x
+	string]int)
+
+	// ParenExpr with comment
+	_ = (add(
+		1, // x
+		2,
+	) + 3) * 4
+
+	// MapType with comment
+	_ = make(map[ // x
+	string]int)
+}

--- a/testdata/expr_comments.input
+++ b/testdata/expr_comments.input
@@ -1,0 +1,44 @@
+package main
+
+func main() {
+	// UnaryExpr with comment
+	_ = !isValid(
+		1, // x
+		2,
+	)
+
+	// IndexExpr with comment
+	_ = getSlice(
+		1, // x
+		2,
+	)[0]
+
+	// SliceExpr with comment
+	_ = getSlice(
+		1, // x
+		2,
+	)[foo(
+		3, // x
+		4,
+	):bar(
+		5, // x
+		6,
+	)]
+
+	// TypeAssertExpr with comment
+	_ = getValue(
+		1, // x
+		2,
+	).(map[ // x
+	string]int)
+
+	// ParenExpr with comment
+	_ = (add(
+		1, // x
+		2,
+	) + 3) * 4
+
+	// MapType with comment
+	_ = make(map[ // x
+	string]int)
+}

--- a/testdata/expr_simple.golden
+++ b/testdata/expr_simple.golden
@@ -1,0 +1,25 @@
+package main
+
+func main() {
+	// UnaryExpr
+	_ = !isValid(1, 2)
+
+	// IndexExpr
+	_ = getSlice(1, 2)[0]
+
+	// SliceExpr
+	_ = getSlice(1, 2)[foo(3, 4):bar(5, 6)]
+
+	// TypeAssertExpr
+	_ = getValue(1, 2).(map[string]int)
+
+	// ParenExpr
+	_ = (add(1, 2) + 3) * 4
+
+	// MapType
+	_ = make(map[string]int)
+
+	// BasicLit (multi-line raw string)
+	_ = `hello
+world`
+}

--- a/testdata/expr_simple.input
+++ b/testdata/expr_simple.input
@@ -1,0 +1,48 @@
+package main
+
+func main() {
+	// UnaryExpr
+	_ = !isValid(
+		1,
+		2,
+	)
+
+	// IndexExpr
+	_ = getSlice(
+		1,
+		2,
+	)[0]
+
+	// SliceExpr
+	_ = getSlice(
+		1,
+		2,
+	)[foo(
+		3,
+		4,
+	):bar(
+		5,
+		6,
+	)]
+
+	// TypeAssertExpr
+	_ = getValue(
+		1,
+		2,
+	).(map[
+	string]int)
+
+	// ParenExpr
+	_ = (add(
+		1,
+		2,
+	) + 3) * 4
+
+	// MapType
+	_ = make(map[
+	string]int)
+
+	// BasicLit (multi-line raw string)
+	_ = `hello
+world`
+}

--- a/testdata/nested_literals.golden
+++ b/testdata/nested_literals.golden
@@ -7,8 +7,14 @@ type Data struct {
 
 func main() {
 	data := []Data{
-		{Values: []string{"a", "b"}, Count: 2},
-		{Values: []string{"x", "y", "z"}, Count: 3},
+		{
+			Values: []string{"a", "b"},
+			Count:  2,
+		},
+		{
+			Values: []string{"x", "y", "z"},
+			Count:  3,
+		},
 	}
 	println(len(data))
 }


### PR DESCRIPTION
Replace the addLines map and applyPost restoration mechanism with a condenseWithChildren function that recursively condenses child expressions before attempting to condense the parent node.

Output changes:
- Calls with a mix of simple and multi-line args (e.g. FuncLit) now preserve one-arg-per-line layout instead of collapsing onto one line
- Struct/map literals with composite values (e.g. KeyValueExpr with slice value) stay expanded instead of being incorrectly condensed
- Comments in a parent node no longer prevent child condensation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More consistent and predictable expression formatting across additional expression forms, with better handling of inline comments and nested constructs.
  * Simplified condensation behavior for multi-part expressions, reducing unexpected multi-line conversions.

* **Tests**
  * Added multiple test cases and example snippets exercising comment placement, complex/nested calls, literals, and varied expression shapes to validate formatting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->