### PR TITLE
chore(golangci-lint): disable auto-fix to flag format issues in CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,5 @@
 version: '2'
 
-issues:
-  fix: true
-
 linters:
   default: all
   disable:

--- a/condenser.go
+++ b/condenser.go
@@ -238,7 +238,6 @@ func (e *condenser) condenseExpr(expr ast.Expr) bool { //nolint:cyclop,funlen
 	}
 }
 
-
 // condenseCallExpr attempts to condense a function call.
 func (e *condenser) condenseCallExpr(call *ast.CallExpr) bool {
 	if !e.config.Enable.has(Calls) {
@@ -531,4 +530,3 @@ func equalFieldList(a, b *ast.FieldList) bool {
 		return equalExpr(x.Type, y.Type)
 	})
 }
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled automatic lint autofix to require manual review of lint fixes.
* **Style**
  * Minor whitespace/formatting cleanup with no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->