### PR TITLE
perf: probe field lists once in condenseFuncType to skip redundant work

### DIFF
--- a/condenser.go
+++ b/condenser.go
@@ -308,46 +308,51 @@ func (e *condenser) condenseBlockStmt(block *ast.BlockStmt) {
 
 // condenseFuncType attempts to condense a function type.
 func (e *condenser) condenseFuncType(funcType *ast.FuncType, feature Feature) bool {
-	if !e.config.Enable.has(feature) {
-		return true
-	}
-	if e.isSingleLine(funcType) || funcType == nil {
+	if !e.config.Enable.has(feature) || e.isSingleLine(funcType) {
 		return true
 	}
 
-	lines := slices.Clone(e.tokenFile.Lines())
+	saved := slices.Clone(e.tokenFile.Lines())
 
-	// Attempt multiple combinations of condensing field lists
-	// to find the best fit without exceeding MaxLen.
-	combinations := [][]*ast.FieldList{
-		{funcType.TypeParams, funcType.Params, funcType.Results},
-		{funcType.TypeParams, funcType.Results},
-		{funcType.Params, funcType.Results},
-		{funcType.Results},
-		{funcType.TypeParams, funcType.Params},
-		{funcType.TypeParams},
-		{funcType.Params},
+	// Probe: condense each field list independently.
+	// Successful condensations modify the line table; failed ones are
+	// restored internally by condenseNode.
+	lists := [3]*ast.FieldList{funcType.TypeParams, funcType.Params, funcType.Results}
+	var ok [3]bool
+	for i, f := range lists {
+		ok[i] = f == nil || e.condenseFieldList(f, feature) //nolint:gosec // index bounded by [3]
 	}
-	success := 0
-	first := true
-	for _, fields := range combinations {
-		if slices.Contains(fields, nil) {
-			continue // Skip combinations with nil fields.
+
+	// Try combinations in preference order, skipping non-viable ones.
+	// The first combo (all) reuses the probe's line state; subsequent ones restore and re-condense.
+	combos := [...][3]bool{
+		{true, true, true},   // TypeParams + Params + Results
+		{true, false, true},  // TypeParams + Results
+		{false, true, true},  // Params + Results
+		{false, false, true}, // Results
+		{true, true, false},  // TypeParams + Params
+		{true, false, false}, // TypeParams
+		{false, true, false}, // Params
+	}
+	for i, c := range combos {
+		if (c[0] && !ok[0]) || (c[1] && !ok[1]) || (c[2] && !ok[2]) {
+			continue // Skip combos requiring non-condensable field lists.
 		}
-		for _, field := range fields {
-			if e.condenseFieldList(field, feature) {
-				success++
+		if i > 0 {
+			e.tokenFile.SetLines(append(e.tokenFile.Lines()[:0], saved...))
+			for j, include := range c {
+				if include {
+					e.condenseFieldList(lists[j], feature) //nolint:gosec // index bounded by [3]
+				}
 			}
 		}
 		if e.canCondense(funcType) {
-			return first && len(fields) == success // Return true if all fields were condensed successfully.
+			return i == 0 // Return true if all fields were condensed successfully.
 		}
-		e.tokenFile.SetLines(slices.Clone(lines))
-		success = 0
-		first = false
 	}
 
-	return first
+	e.tokenFile.SetLines(saved)
+	return false
 }
 
 // hasCommentsInRange checks if any comment overlaps with the given position range.

--- a/testdata/func_type_combos.golden
+++ b/testdata/func_type_combos.golden
@@ -1,0 +1,60 @@
+package example
+
+// Combo 1: all condensable.
+func All[T any](a T, b string) (string, error) {
+	return "", nil
+}
+
+// Combo 2: Params has comment.
+func TypeParamsAndResults[T any](
+	a T, // keep
+	b string,
+) (string, error) {
+	return "", nil
+}
+
+// Combo 3: TypeParams has comment.
+func ParamsAndResults[
+	T any, // keep
+](a T, b string) (string, error) {
+	return "", nil
+}
+
+// Combo 4: TypeParams and Params have comments.
+func ResultsOnly[
+	T any, // keep
+](
+	a T, // keep
+	b string,
+) (string, error) {
+	return "", nil
+}
+
+// Combo 5: Results has comment.
+func TypeParamsAndParams[T any](a T, b string) (
+	string,
+	error, // keep
+) {
+	return "", nil
+}
+
+// Combo 6: Params and Results have comments.
+func TypeParamsOnly[T any](
+	a T, // keep
+	b string,
+) (
+	string,
+	error, // keep
+) {
+	return "", nil
+}
+
+// Combo 7: TypeParams and Results have comments.
+func ParamsOnly[
+	T any, // keep
+](a T, b string) (
+	string,
+	error, // keep
+) {
+	return "", nil
+}

--- a/testdata/func_type_combos.input
+++ b/testdata/func_type_combos.input
@@ -1,0 +1,92 @@
+package example
+
+// Combo 1: all condensable.
+func All[
+	T any,
+](
+	a T,
+	b string,
+) (
+	string,
+	error,
+) {
+	return "", nil
+}
+
+// Combo 2: Params has comment.
+func TypeParamsAndResults[
+	T any,
+](
+	a T,    // keep
+	b string,
+) (
+	string,
+	error,
+) {
+	return "", nil
+}
+
+// Combo 3: TypeParams has comment.
+func ParamsAndResults[
+	T any, // keep
+](
+	a T,
+	b string,
+) (
+	string,
+	error,
+) {
+	return "", nil
+}
+
+// Combo 4: TypeParams and Params have comments.
+func ResultsOnly[
+	T any, // keep
+](
+	a T,    // keep
+	b string,
+) (
+	string,
+	error,
+) {
+	return "", nil
+}
+
+// Combo 5: Results has comment.
+func TypeParamsAndParams[
+	T any,
+](
+	a T,
+	b string,
+) (
+	string,
+	error, // keep
+) {
+	return "", nil
+}
+
+// Combo 6: Params and Results have comments.
+func TypeParamsOnly[
+	T any,
+](
+	a T,    // keep
+	b string,
+) (
+	string,
+	error, // keep
+) {
+	return "", nil
+}
+
+// Combo 7: TypeParams and Results have comments.
+func ParamsOnly[
+	T any, // keep
+](
+	a T,
+	b string,
+) (
+	string,
+	error, // keep
+) {
+	return "", nil
+}


### PR DESCRIPTION
Each field list is now probed once upfront and combos containing non-condensable lists are skipped, avoiding redundant condenseExpr walks and format.Node calls. Line buffer is reused on restore instead of cloning.

This is unlikely to affect benchmarks as the benchmark code only contains functions that can be fully condensed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More robust condensation/formatting logic for generic function signatures, with improved handling of multiple field-list combinations, state restoration between attempts, and preserved behavior for disabled or single-line cases.

* **Tests**
  * Added comprehensive test cases exercising many comment placements around type parameters, parameters, and results to ensure consistent formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->