### PR TITLE
chore(golangci-lint): disable gosec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - forcetypeassert
     - gochecknoglobals
     - gocyclo
+    - gosec
     - godox
     - mnd
     - nlreturn

--- a/cmd/gocondense/main.go
+++ b/cmd/gocondense/main.go
@@ -26,7 +26,7 @@ func main() { //nolint:funlen
 	)
 
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: %s [options] [file|dir|path/...]", os.Args[0]) //nolint:gosec // false positive
+		fmt.Fprintf(os.Stderr, "Usage: %s [options] [file|dir|path/...]", os.Args[0])
 		fmt.Fprintf(os.Stderr, "\nCondenses multi-line Go constructs into single-line constructs where appropriate.\n")
 		fmt.Fprintf(os.Stderr, "If no file is provided, reads from stdin and writes to stdout.\n\n")
 		fmt.Fprintf(os.Stderr, "Options:\n")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linter configuration to disable gosec
* **Style**
  * Removed formatting directive from command usage output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->