### PR TITLE
feat(cli): skip generated files and vendor directories during directory walks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/abemedia/gocondense)](https://goreportcard.com/report/github.com/abemedia/gocondense)
 
 A Go source code formatter that condenses multi-line constructs onto single
-lines where they fit, reducing vertical noise while preserving readability. All
-transformations are line-length aware (default 80 columns), idempotent, and
-preserve all comments. Generated files are skipped automatically.
+lines where they fit, reducing vertical noise while preserving readability.  
+All transformations are line-length aware (default 80 columns), idempotent, and
+preserve all comments.
 
 ## Installation
 
@@ -29,7 +29,8 @@ cat file.go | gocondense          # read from stdin, write to stdout
 
 When no arguments are provided, the formatter reads from standard input and
 writes the result to standard output. When file or directory arguments are
-provided, source files are modified in-place.
+provided, source files are modified in-place. Generated files and vendor
+directories are skipped during directory walks.
 
 | Flag          | Description                                                             | Default |
 | ------------- | ----------------------------------------------------------------------- | ------- |

--- a/cmd/gocondense/main.go
+++ b/cmd/gocondense/main.go
@@ -40,12 +40,17 @@ func main() { //nolint:funlen
 		return
 	}
 
-	config := &gocondense.Config{
+	formatter := gocondense.New(&gocondense.Config{
 		MaxLen:   *maxLen,
 		TabWidth: *tabWidth,
-	}
+	})
 
-	formatter := gocondense.New(config)
+	// For directory walks, skip generated files automatically.
+	dirFormatter := gocondense.New(&gocondense.Config{
+		MaxLen:        *maxLen,
+		TabWidth:      *tabWidth,
+		SkipGenerated: true,
+	})
 
 	if flag.NArg() == 0 {
 		// Read from stdin
@@ -79,7 +84,10 @@ func main() { //nolint:funlen
 			continue
 		}
 
-		isDir := info.IsDir()
+		f := formatter
+		if info.IsDir() {
+			f = dirFormatter
+		}
 
 		err = filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
@@ -94,9 +102,9 @@ func main() { //nolint:funlen
 				go func(path string) {
 					defer sem.Release(1)
 					defer wg.Done()
-					processFile(formatter, path)
+					processFile(f, path)
 				}(path)
-			} else if info.IsDir() && !recursive && isDir && path != arg {
+			} else if info.IsDir() && path != arg && (!recursive || filepath.Base(path) == "vendor") {
 				return filepath.SkipDir
 			}
 			return nil

--- a/formatter.go
+++ b/formatter.go
@@ -22,6 +22,10 @@ type Config struct {
 	// when calculating line lengths.
 	// If 0, defaults to 4 spaces.
 	TabWidth int
+
+	// SkipGenerated causes Format to return the source unchanged for
+	// files that contain a "Code generated ... DO NOT EDIT" comment.
+	SkipGenerated bool
 }
 
 // DefaultConfig provides a sensible default configuration with a maximum
@@ -64,7 +68,7 @@ func (f *Formatter) Format(src []byte) ([]byte, error) {
 		return nil, fmt.Errorf("failed to parse source: %w", err)
 	}
 
-	if ast.IsGenerated(file) {
+	if f.config.SkipGenerated && ast.IsGenerated(file) {
 		return src, nil
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to skip generated files during directory scans and applied selective skipping for directories versus individual files.
  * Improved handling of vendor directories during traversal.

* **Documentation**
  * Clarified README guidance about how generated files and vendor directories are treated during scans and adjusted wording/line breaks for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->