### PR TITLE
feat: add -l and -d flags for check-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ unless explicitly specified as arguments.
 | ------------- | ----------------------------------------------------------------------- | ------- |
 | `--max-len`   | Maximum line length; constructs exceeding this remain on multiple lines | 80      |
 | `--tab-width` | Tab character width used for line length calculation                    | 4       |
+| `-l`          | List files whose formatting differs (exit 1 if any)                     |         |
+| `-d`          | Display diffs instead of rewriting files (exit 1 if any)                |         |
 
 ## Transformations
 

--- a/cmd/gocondense/diff.go
+++ b/cmd/gocondense/diff.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -22,7 +23,8 @@ func unifiedDiff(filename string, old, cur []byte) string {
 	}
 
 	var b strings.Builder
-	fmt.Fprintf(&b, "--- %s\n+++ %s\n", filepath.Join("a", filename), filepath.Join("b", filename))
+	name := filepath.ToSlash(filename)
+	fmt.Fprintf(&b, "--- %s\n+++ %s\n", path.Join("a", name), path.Join("b", name))
 	writeHunks(&b, edits, oldLines, newLines)
 	return b.String()
 }

--- a/cmd/gocondense/diff.go
+++ b/cmd/gocondense/diff.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+type edit struct {
+	op   byte // '=', '-', '+'
+	oldI int
+	newI int
+}
+
+// unifiedDiff returns a unified diff between old and new content for filename.
+func unifiedDiff(filename string, old, cur []byte) string {
+	oldLines := splitLines(old)
+	newLines := splitLines(cur)
+	edits := myersDiff(oldLines, newLines)
+	if len(edits) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "--- %s\n+++ %s\n", filepath.Join("a", filename), filepath.Join("b", filename))
+	writeHunks(&b, edits, oldLines, newLines)
+	return b.String()
+}
+
+const diffContextLines = 3
+
+// writeHunks groups edits into unified-diff hunks and writes them to b.
+func writeHunks(b *strings.Builder, edits []edit, oldLines, newLines []string) {
+	i := 0
+	for i < len(edits) {
+		for i < len(edits) && edits[i].op == '=' {
+			i++
+		}
+		if i >= len(edits) {
+			break
+		}
+
+		start := i
+		for start > 0 && edits[start-1].op == '=' && i-start+1 <= diffContextLines {
+			start--
+		}
+
+		j := hunkEnd(edits, i)
+		writeHunk(b, edits[start:j], oldLines, newLines)
+		i = j
+	}
+}
+
+// hunkEnd returns the end index of a hunk starting at the first change at pos i.
+func hunkEnd(edits []edit, i int) int {
+	j := i
+	for {
+		for j < len(edits) && edits[j].op != '=' {
+			j++
+		}
+		end := j
+		for end < len(edits) && edits[end].op == '=' && end-j < diffContextLines {
+			end++
+		}
+		if end < len(edits) && edits[end].op != '=' {
+			j = end
+			continue
+		}
+		return end
+	}
+}
+
+// writeHunk writes a single hunk header and lines to b.
+func writeHunk(b *strings.Builder, hunkEdits []edit, oldLines, newLines []string) {
+	var oldStart, oldCount, newStart, newCount int
+	var lines []string
+	for _, e := range hunkEdits {
+		switch e.op {
+		case '=':
+			lines = append(lines, " "+oldLines[e.oldI])
+			oldCount++
+			newCount++
+		case '-':
+			lines = append(lines, "-"+oldLines[e.oldI])
+			oldCount++
+		case '+':
+			lines = append(lines, "+"+newLines[e.newI])
+			newCount++
+		}
+	}
+
+	for _, e := range hunkEdits {
+		if e.op != '+' {
+			oldStart = e.oldI + 1
+			break
+		}
+	}
+	for _, e := range hunkEdits {
+		if e.op != '-' {
+			newStart = e.newI + 1
+			break
+		}
+	}
+
+	fmt.Fprintf(b, "@@ -%d,%d +%d,%d @@\n", oldStart, oldCount, newStart, newCount)
+	for _, l := range lines {
+		b.WriteString(l)
+		b.WriteByte('\n')
+	}
+}
+
+// myersDiff computes a minimal edit script between two line slices.
+func myersDiff(oldLines, newLines []string) []edit {
+	n, m := len(oldLines), len(newLines)
+	total := n + m
+	if total == 0 {
+		return nil
+	}
+
+	vs := myersForward(oldLines, newLines, n, m, total)
+	return myersBacktrack(vs, n, m)
+}
+
+// myersForward runs the forward phase of the Myers diff algorithm,
+// returning the saved v-states for backtracking.
+func myersForward(oldLines, newLines []string, n, m, total int) [][]int {
+	v := make([]int, 2*total+1)
+	vs := make([][]int, 0, total)
+
+	for d := 0; d <= total; d++ {
+		vc := make([]int, len(v))
+		copy(vc, v)
+		vs = append(vs, vc)
+		for k := -d; k <= d; k += 2 {
+			var x int
+			if k == -d || (k != d && v[k-1+total] < v[k+1+total]) {
+				x = v[k+1+total]
+			} else {
+				x = v[k-1+total] + 1
+			}
+			y := x - k
+			for x < n && y < m && oldLines[x] == newLines[y] {
+				x++
+				y++
+			}
+			v[k+total] = x
+			if x >= n && y >= m {
+				return vs
+			}
+		}
+	}
+	return vs
+}
+
+// myersBacktrack recovers the edit script from the saved v-states.
+func myersBacktrack(vs [][]int, n, m int) []edit {
+	total := n + m
+	x, y := n, m
+	var edits []edit
+	for d := len(vs) - 1; d >= 0; d-- {
+		vd := vs[d]
+		k := x - y
+		var prevK int
+		if k == -d || (k != d && vd[k-1+total] < vd[k+1+total]) {
+			prevK = k + 1
+		} else {
+			prevK = k - 1
+		}
+		prevX := vd[prevK+total]
+		prevY := prevX - prevK
+		for x > prevX && y > prevY {
+			x--
+			y--
+			edits = append(edits, edit{'=', x, y})
+		}
+		if d > 0 {
+			if x > prevX {
+				x--
+				edits = append(edits, edit{'-', x, 0})
+			} else {
+				y--
+				edits = append(edits, edit{'+', 0, y})
+			}
+		}
+	}
+	for i, j := 0, len(edits)-1; i < j; i, j = i+1, j-1 {
+		edits[i], edits[j] = edits[j], edits[i]
+	}
+	return edits
+}
+
+// splitLines splits data into lines, stripping the trailing newline from each.
+func splitLines(data []byte) []string {
+	s := string(data)
+	if s == "" {
+		return nil
+	}
+	lines := strings.Split(s, "\n")
+	if lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}

--- a/cmd/gocondense/main.go
+++ b/cmd/gocondense/main.go
@@ -238,11 +238,17 @@ func processFile(
 	}
 
 	if listOnly {
-		fmt.Fprintln(stdout, filename)
+		if _, err := fmt.Fprintln(stdout, filename); err != nil {
+			fmt.Fprintf(stderr, "Error writing output: %v\n", err)
+			return resultError
+		}
 		return resultChanged
 	}
 	if showDiff {
-		fmt.Fprint(stdout, unifiedDiff(filename, input, output))
+		if _, err := fmt.Fprint(stdout, unifiedDiff(filename, input, output)); err != nil {
+			fmt.Fprintf(stderr, "Error writing output: %v\n", err)
+			return resultError
+		}
 		return resultChanged
 	}
 

--- a/cmd/gocondense/main.go
+++ b/cmd/gocondense/main.go
@@ -52,6 +52,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 
 	maxLen := flags.Int("max-len", 80, "maximum line length before keeping multi-line")
 	tabWidth := flags.Int("tab-width", 4, "width of a tab character for line length calculation")
+	listOnly := flags.Bool("l", false, "list files whose formatting differs")
+	showDiff := flags.Bool("d", false, "display diffs instead of rewriting files")
 
 	flags.Usage = func() {
 		fmt.Fprintf(stderr, "Usage: %s [options] [file|dir|path/...]", args[0])
@@ -82,7 +84,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	if flags.NArg() == 0 {
 		return formatStdin(formatter, stdin, stdout, stderr)
 	}
-	return processArgs(formatter, flags.Args(), stderr)
+	return processArgs(formatter, flags.Args(), stdout, stderr, *listOnly, *showDiff)
 }
 
 // formatStdin reads Go source from stdin, formats it, and writes to stdout.
@@ -121,11 +123,17 @@ func formatStdin(formatter *gocondense.Formatter, stdin io.Reader, stdout, stder
 }
 
 // processArgs formats the given file and directory arguments concurrently.
-func processArgs(formatter *gocondense.Formatter, args []string, stderr io.Writer) int {
+func processArgs( //nolint:funlen
+	formatter *gocondense.Formatter,
+	args []string,
+	stdout, stderr io.Writer,
+	listOnly, showDiff bool,
+) int {
 	var (
-		wg        sync.WaitGroup
-		hasErrors atomic.Bool
-		sem       = semaphore.NewWeighted(int64(runtime.NumCPU()))
+		wg         sync.WaitGroup
+		hasErrors  atomic.Bool
+		hasChanged atomic.Bool
+		sem        = semaphore.NewWeighted(int64(runtime.NumCPU()))
 	)
 
 	for _, arg := range args {
@@ -158,8 +166,11 @@ func processArgs(formatter *gocondense.Formatter, args []string, stderr io.Write
 				go func() {
 					defer sem.Release(1)
 					defer wg.Done()
-					if !processFile(formatter, p, skipGenerated, stderr) {
+					switch processFile(formatter, p, skipGenerated, stdout, stderr, listOnly, showDiff) {
+					case resultError:
 						hasErrors.Store(true)
+					case resultChanged:
+						hasChanged.Store(true)
 					}
 				}()
 			}
@@ -174,26 +185,43 @@ func processArgs(formatter *gocondense.Formatter, args []string, stderr io.Write
 	if hasErrors.Load() {
 		return 2
 	}
+	if (listOnly || showDiff) && hasChanged.Load() {
+		return 1
+	}
 	return 0
 }
 
+type result int
+
+const (
+	resultOK      result = iota // no changes needed or file written successfully
+	resultChanged               // file differs (used with -l/-d)
+	resultError                 // an error occurred
+)
+
 // processFile reads, formats, and writes back a single Go file.
-func processFile(formatter *gocondense.Formatter, filename string, skipGenerated bool, stderr io.Writer) bool {
+func processFile(
+	formatter *gocondense.Formatter,
+	filename string,
+	skipGenerated bool,
+	stdout, stderr io.Writer,
+	listOnly, showDiff bool,
+) result {
 	input, err := os.ReadFile(filename)
 	if err != nil {
 		fmt.Fprintf(stderr, "Error reading file %s: %v\n", filename, err)
-		return false
+		return resultError
 	}
 
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, filename, input, parserMode)
 	if err != nil {
 		fmt.Fprintf(stderr, "Error parsing file %s: %v\n", filename, err)
-		return false
+		return resultError
 	}
 
 	if skipGenerated && ast.IsGenerated(file) {
-		return true
+		return resultOK
 	}
 
 	formatter.File(fset, file)
@@ -201,21 +229,30 @@ func processFile(formatter *gocondense.Formatter, filename string, skipGenerated
 	var buf bytes.Buffer
 	if err := goformat.Node(&buf, fset, file); err != nil {
 		fmt.Fprintf(stderr, "Error formatting file %s: %v\n", filename, err)
-		return false
+		return resultError
 	}
 	output := buf.Bytes()
 
 	if bytes.Equal(input, output) {
-		return true
+		return resultOK
+	}
+
+	if listOnly {
+		fmt.Fprintln(stdout, filename)
+		return resultChanged
+	}
+	if showDiff {
+		fmt.Fprint(stdout, unifiedDiff(filename, input, output))
+		return resultChanged
 	}
 
 	err = os.WriteFile(filename, output, 0o600)
 	if err != nil {
 		fmt.Fprintf(stderr, "Error writing file %s: %v\n", filename, err)
-		return false
+		return resultError
 	}
 
-	return true
+	return resultOK
 }
 
 // shouldIgnore reports whether dir should be skipped.

--- a/cmd/gocondense/main_test.go
+++ b/cmd/gocondense/main_test.go
@@ -44,6 +44,21 @@ const (
 	generatedCondensed = generatedPrefix + condensed
 )
 
+var diffOutput = "" +
+	"--- a/a.go\n" +
+	"+++ b/a.go\n" +
+	"@@ -3,9 +3,5 @@\n" +
+	" import \"fmt\"\n" +
+	" \n" +
+	" func greet(first, last string) string {\n" +
+	"-\treturn fmt.Sprintf(\n" +
+	"-\t\t\"Hello, %s %s!\",\n" +
+	"-\t\tfirst,\n" +
+	"-\t\tlast,\n" +
+	"-\t)\n" +
+	"+\treturn fmt.Sprintf(\"Hello, %s %s!\", first, last)\n" +
+	" }\n"
+
 var errTest = errors.New("test error")
 
 type errWriter struct{}
@@ -268,6 +283,96 @@ func TestRun(t *testing.T) {
 			wantFiles: map[string]string{
 				"sub/sub.go": condensed,
 			},
+		},
+		// -l flag
+		{
+			name: "l_lists_changed_files",
+			args: []string{"-l", "a.go", "b.go"},
+			files: map[string]string{
+				"a.go": uncondensed,
+				"b.go": condensed,
+			},
+			wantCode:   1,
+			wantStdout: "a.go\n",
+			wantFiles: map[string]string{
+				"a.go": uncondensed, // not modified
+				"b.go": condensed,   // not modified
+			},
+		},
+		{
+			name: "l_no_changes",
+			args: []string{"-l", "a.go"},
+			files: map[string]string{
+				"a.go": condensed,
+			},
+			wantFiles: map[string]string{
+				"a.go": condensed,
+			},
+		},
+		{
+			name: "l_directory_recursive",
+			args: []string{"-l", "./..."},
+			files: map[string]string{
+				"top.go":     uncondensed,
+				"sub/sub.go": condensed,
+			},
+			wantCode:   1,
+			wantStdout: "top.go\n",
+			wantFiles: map[string]string{
+				"top.go":     uncondensed,
+				"sub/sub.go": condensed,
+			},
+		},
+		{
+			name: "l_skips_generated",
+			args: []string{"-l", "./..."},
+			files: map[string]string{
+				"gen.go": generated,
+				"a.go":   uncondensed,
+			},
+			wantCode:   1,
+			wantStdout: "a.go\n",
+			wantFiles: map[string]string{
+				"gen.go": generated,
+				"a.go":   uncondensed,
+			},
+		},
+		{
+			name:       "l_parse_error",
+			args:       []string{"-l", "bad.go"},
+			files:      map[string]string{"bad.go": "not valid go"},
+			wantCode:   2,
+			wantStderr: "Error parsing file",
+		},
+		// -d flag
+		{
+			name: "d_shows_diff",
+			args: []string{"-d", "a.go"},
+			files: map[string]string{
+				"a.go": uncondensed,
+			},
+			wantCode:   1,
+			wantStdout: diffOutput,
+			wantFiles: map[string]string{
+				"a.go": uncondensed, // not modified
+			},
+		},
+		{
+			name: "d_no_changes",
+			args: []string{"-d", "a.go"},
+			files: map[string]string{
+				"a.go": condensed,
+			},
+			wantFiles: map[string]string{
+				"a.go": condensed,
+			},
+		},
+		{
+			name:       "d_parse_error",
+			args:       []string{"-d", "bad.go"},
+			files:      map[string]string{"bad.go": "not valid go"},
+			wantCode:   2,
+			wantStderr: "Error parsing file",
 		},
 	}
 


### PR DESCRIPTION
## Add `-l` and `-d` flags for check-only mode

### Summary

- Add `-l` flag that lists files whose formatting would change (without modifying them)
- Add `-d` flag that prints a unified diff of what would change (without modifying them)
- Exit code 1 when either flag detects differences, matching the `gofmt` convention (0 = clean, 1 = diffs found, 2 = errors)

### Motivation

There's currently no way to use gocondense in CI or pre-commit hooks to *check* formatting without rewriting files. Tools like `gofmt -l` and `goimports -l` support this and it's become the standard pattern for Go formatting checks:

```sh
# CI check: fail if any files need condensing
gocondense -l ./... && echo "ok" || echo "needs formatting"
```

Without this, the workaround is piping each file through stdin and diffing manually or copying the files to a tmp dir, running gocondense, and checking for changes.

### What changed

All changes are in `cmd/gocondense/` (library is untouched):

- `main.go`: two new flags (`-l` and `-d`); `processFile` returns a 3-way result (`resultOK` / `resultChanged` / `resultError`) instead of `bool`, so `processArgs` can distinguish "file differs" from "error" for the exit code. 
- `processArgs` has a `//nolint:funlen` because it was already near the 60-line limit and the new result handling pushes it slightly over; extracting a helper would mean refactoring the existing function (decision for the original author).
- `diff.go` (new): unified diff output using Myers algorithm, pure Go with no new dependencies

### Tests

- [x] `-l` lists only files that differ, leaves all files unmodified
- [x] `-l` returns exit 0 when nothing differs
- [x] `-l` works with recursive directory walking (`./...`)
- [x] `-l` respects generated-file skipping
- [x] `-l` returns exit 2 on parse errors
- [x] `-d` prints correct unified diff, leaves files unmodified
- [x] `-d` returns exit 0 when nothing differs
- [x] `-d` returns exit 2 on parse errors
- [x] All existing tests still pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generates unified diffs for changed files and supports a diff view output.
  * Added `-l` (list changed files) and `-d` (show diffs) CLI flags.

* **Behavior Changes**
  * When `-l` or `-d` are used, diffs or filenames are written to stdout; otherwise files are updated.
  * Exit code 1 signals detected changes with those flags; exit code 2 signals errors.

* **Tests**
  * Added tests for `-l` and `-d` covering multiple files, no-change cases, recursive patterns, and error handling.

* **Documentation**
  * README updated to document the new `-l` and `-d` flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->