### PR TITLE
fix: prevent partial collapse of multi-line binary expression chains

### DIFF
--- a/condenser.go
+++ b/condenser.go
@@ -82,8 +82,12 @@ func (e *condenser) applyPost(c *astutil.Cursor) bool { //nolint:cyclop,funlen,g
 	case *ast.CallExpr:
 		e.condenseCallExpr(n)
 	case *ast.BinaryExpr:
-		if !e.isSingleLine(n) && e.isSingleLine(n.X) && e.isSingleLine(n.Y) && !e.hasComments(n) {
-			e.condenseNode(n)
+		// Each precedence-chain collapses atomically from its top; tighter
+		// sub-expressions (e.g. `b*c` in `a + b*c + d`) are their own chain.
+		if p, ok := e.parent(1).(*ast.BinaryExpr); !ok || n.Op.Precedence() > p.Op.Precedence() {
+			if !e.isSingleLine(n) && !e.hasComments(n) {
+				e.condenseNode(n)
+			}
 		}
 	case *ast.SelectorExpr:
 		if !e.isSingleLine(n) && e.isSingleLine(n.X) && !e.hasComments(n) {

--- a/testdata/binary_chain.golden
+++ b/testdata/binary_chain.golden
@@ -1,0 +1,44 @@
+package main
+
+func main() {
+	// Chain fits - condense
+	_ = shortA + shortB + shortC
+
+	// Chain too long - keep multi-line
+	_ = longVariableNameA +
+		longVariableNameB +
+		longVariableNameC +
+		longVariableNameD
+
+	// Mixed precedence too long - condense the higher-precedence sub-expression
+	_ = longVariableNameA +
+		longVariableNameB*longVariableNameC +
+		longVariableNameD
+
+	// Mixed precedence where sub-expression itself does not fit - keep multi-line
+	_ = longVariableNameA +
+		longVariableNameB*
+			longVariableNameC*
+			longVariableNameE*
+			longVariableNameF*
+			longVariableNameG +
+		longVariableNameD
+
+	// Partial wrap too long when joined - preserve
+	_ = longVariableNameA + longVariableNameB +
+		longVariableNameC + longVariableNameD
+
+	// Paren sub-chain fits - condense even when outer stays multi-line
+	_ = (shortA + shortB) +
+		veryLongVariableNameThatPushesPastTheEightyCharacterLimitOfTheLine
+
+	// Paren sub-chains and outer all fit - join, parens preserved
+	_ = (shortA + shortB) + (shortC + shortD)
+
+	// Paren sub-chain too long - keep multi-line
+	_ = (longVariableNameA +
+		longVariableNameB +
+		longVariableNameC +
+		longVariableNameD) +
+		shortE
+}

--- a/testdata/binary_chain.input
+++ b/testdata/binary_chain.input
@@ -1,0 +1,50 @@
+package main
+
+func main() {
+	// Chain fits - condense
+	_ = shortA +
+		shortB +
+		shortC
+
+	// Chain too long - keep multi-line
+	_ = longVariableNameA +
+		longVariableNameB +
+		longVariableNameC +
+		longVariableNameD
+
+	// Mixed precedence too long - condense the higher-precedence sub-expression
+	_ = longVariableNameA +
+		longVariableNameB*
+			longVariableNameC +
+		longVariableNameD
+
+	// Mixed precedence where sub-expression itself does not fit - keep multi-line
+	_ = longVariableNameA +
+		longVariableNameB*
+			longVariableNameC*
+			longVariableNameE*
+			longVariableNameF*
+			longVariableNameG +
+		longVariableNameD
+
+	// Partial wrap too long when joined - preserve
+	_ = longVariableNameA + longVariableNameB +
+		longVariableNameC + longVariableNameD
+
+	// Paren sub-chain fits - condense even when outer stays multi-line
+	_ = (shortA +
+		shortB) +
+		veryLongVariableNameThatPushesPastTheEightyCharacterLimitOfTheLine
+
+	// Paren sub-chains and outer all fit - join, parens preserved
+	_ = (shortA +
+		shortB) + (shortC +
+		shortD)
+
+	// Paren sub-chain too long - keep multi-line
+	_ = (longVariableNameA +
+		longVariableNameB +
+		longVariableNameC +
+		longVariableNameD) +
+		shortE
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multi-line chained operations by respecting operator precedence rules when deciding whether to condense expressions onto a single line.

* **Tests**
  * Added comprehensive test coverage for chained operation formatting, including scenarios with mixed operator precedence, parenthesized sub-expressions, and edge cases with variable line lengths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/abemedia/gocondense/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->