### PR TITLE
docs: document partial condensing of mixed-precedence binary chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ unless explicitly specified as arguments.
 <details><summary><b>Condense function signatures</b></summary>
 
 Multi-line parameter lists, return types, and type parameter lists are condensed
-onto single lines. Each part is condensed independently — for example,
-parameters with comments remain multi-line while return types are still
-condensed.
+onto single lines. Each part is condensed independently. For example, parameters
+with comments remain multi-line while return types are still condensed.
 
 ```go
 func Add[
@@ -180,8 +179,9 @@ p := Person{
 <details><summary><b>Condense expressions</b></summary>
 
 Binary expressions, selector chains, and generic type instantiations that span
-multiple lines are condensed onto a single line, provided both sides of the
-expression are single-line.
+multiple lines are condensed onto a single line. In a mixed-precedence chain,
+the higher-precedence expression is condensed on its own even when the
+surrounding chain stays multi-line.
 
 ```go
 _ = a +
@@ -200,6 +200,21 @@ _ = a + b
 _ = obj.Method
 
 _ = g[int, string](1, "a")
+```
+
+Partial condensing in a mixed-precedence chain:
+
+```go
+_ = a + // keep
+    b*
+        c +
+    d
+```
+
+```go
+_ = a + // keep
+    b*c +
+    d
 ```
 
 </details>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added example demonstrating how operator precedence and comments affect partial condensing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/abemedia/gocondense/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->